### PR TITLE
Basic python3 compatibility, URLGetter superclass

### DIFF
--- a/Genymobile/Genymotion.download.recipe
+++ b/Genymobile/Genymotion.download.recipe
@@ -12,7 +12,7 @@
 		<string>Genymotion</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>1.4</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Genymobile/Genymotion.munki.recipe
+++ b/Genymobile/Genymotion.munki.recipe
@@ -33,7 +33,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>1.4</string>
 	<key>ParentRecipe</key>
 	<string>com.github.erikng.download.Genymotion</string>
 	<key>Process</key>

--- a/Genymobile/GenymotionURLProvider.py
+++ b/Genymobile/GenymotionURLProvider.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+from __future__ import absolute_import
 import json
 import urllib2
 

--- a/Genymobile/GenymotionURLProvider.py
+++ b/Genymobile/GenymotionURLProvider.py
@@ -1,45 +1,44 @@
 #!/usr/bin/python
 
-from __future__ import absolute_import
-
 import json
-import urllib2
 
-from autopkglib import Processor, ProcessorError
+from autopkglib import Processor, ProcessorError, URLGetter
 
 __all__ = ["GenymotionURLProvider"]
 
-class GenymotionURLProvider(Processor):
-    decription = ("Uses Genymotion API to find the latest version of application.")
-    input_variables = {
-    }
-    output_variables = {
-        'genymotion_version': {
-            'description': 'Version number',
-        }
-    }
+
+class GenymotionURLProvider(URLGetter):
+    """Processor class."""
+
+    decription = "Uses Genymotion API to find the latest version of application."
+    input_variables = {}
+    output_variables = {"genymotion_version": {"description": "Version number",}}
 
     description = __doc__
 
     def get_version(self):
+        """Get version from Genymotion API."""
+
         # Genymotion Update API
-        url = 'https://cloud.genymotion.com/launchpad/last_version/mac/x64/'
+        url = "https://cloud.genymotion.com/launchpad/last_version/mac/x64/"
         # API requires AJAX / XMLHttpRequest
-        headers = {'X-Requested-With': 'XMLHttpRequest', 'User-Agent': 'Safari'}
+        headers = {"X-Requested-With": "XMLHttpRequest", "User-Agent": "Safari"}
         try:
-            request = urllib2.Request(url, headers=headers)
-            response = urllib2.urlopen(request)
+            response = self.download(url, headers=headers)
             # Convert response to JSON
-            jsondata = json.loads(response.read())
-            # Example json return - {u'url': u'http://files2.genymotion.com/genymotion/genymotion-2.7.2/genymotion-2.7.2.dmg', u'version': u'2.7.2'}
-            return jsondata['version']
+            jsondata = json.loads(response)
+            # Example json return: {u'url': u'http://files2.genymotion.com/genymotion/genymotion-2.7.2/genymotion-2.7.2.dmg', u'version': u'2.7.2'}
+            return jsondata["version"]
         except:
-            raise ProcessorError('Could not retrieve version from URL: %s' % url)
+            raise ProcessorError("Could not retrieve version from URL: %s" % url)
 
     def main(self):
-        self.env['genymotion_version'] = self.get_version()
-        self.output('Version: %s' % self.env['genymotion_version'])
+        """Main process."""
 
-if __name__ == '__main__':
-    processor = GenymotionURLProvider()
-    processor.execute_shell()
+        self.env["genymotion_version"] = self.get_version()
+        self.output("Version: %s" % self.env["genymotion_version"])
+
+
+if __name__ == "__main__":
+    PROCESSOR = GenymotionURLProvider()
+    PROCESSOR.execute_shell()

--- a/Genymobile/GenymotionURLProvider.py
+++ b/Genymobile/GenymotionURLProvider.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 
 from __future__ import absolute_import
+
 import json
 import urllib2
 

--- a/Genymobile/GenymotionURLProvider.py
+++ b/Genymobile/GenymotionURLProvider.py
@@ -9,36 +9,36 @@ from autopkglib import Processor, ProcessorError
 __all__ = ["GenymotionURLProvider"]
 
 class GenymotionURLProvider(Processor):
-	decription = ("Uses Genymotion API to find the latest version of application.")
-	input_variables = {
-	}
-	output_variables = {
-		'genymotion_version': {
-			'description': 'Version number',
-		}
-	}
+    decription = ("Uses Genymotion API to find the latest version of application.")
+    input_variables = {
+    }
+    output_variables = {
+        'genymotion_version': {
+            'description': 'Version number',
+        }
+    }
 
-	description = __doc__
+    description = __doc__
 
-	def get_version(self):
-		# Genymotion Update API
-		url = 'https://cloud.genymotion.com/launchpad/last_version/mac/x64/'
-		# API requires AJAX / XMLHttpRequest
-		headers = {'X-Requested-With': 'XMLHttpRequest', 'User-Agent': 'Safari'}
-		try:
-			request = urllib2.Request(url, headers=headers)
-			response = urllib2.urlopen(request)
-			# Convert response to JSON
-			jsondata = json.loads(response.read())
-			# Example json return - {u'url': u'http://files2.genymotion.com/genymotion/genymotion-2.7.2/genymotion-2.7.2.dmg', u'version': u'2.7.2'}
-			return jsondata['version']
-		except:
-			raise ProcessorError('Could not retrieve version from URL: %s' % url)
+    def get_version(self):
+        # Genymotion Update API
+        url = 'https://cloud.genymotion.com/launchpad/last_version/mac/x64/'
+        # API requires AJAX / XMLHttpRequest
+        headers = {'X-Requested-With': 'XMLHttpRequest', 'User-Agent': 'Safari'}
+        try:
+            request = urllib2.Request(url, headers=headers)
+            response = urllib2.urlopen(request)
+            # Convert response to JSON
+            jsondata = json.loads(response.read())
+            # Example json return - {u'url': u'http://files2.genymotion.com/genymotion/genymotion-2.7.2/genymotion-2.7.2.dmg', u'version': u'2.7.2'}
+            return jsondata['version']
+        except:
+            raise ProcessorError('Could not retrieve version from URL: %s' % url)
 
-	def main(self):
-		self.env['genymotion_version'] = self.get_version()
-		self.output('Version: %s' % self.env['genymotion_version'])
+    def main(self):
+        self.env['genymotion_version'] = self.get_version()
+        self.output('Version: %s' % self.env['genymotion_version'])
 
 if __name__ == '__main__':
-	processor = GenymotionURLProvider()
-	processor.execute_shell()
+    processor = GenymotionURLProvider()
+    processor.execute_shell()


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

Sorry for the large diff, but I think changing indentation to spaces will be helpful for potentially [Blackening](https://black.readthedocs.io/en/stable/) all AutoPkg Python code someday.

More adjustments may need to be made manually later (including handling HTTP headers), but this should catch the low-hanging fruit right now.