### PR TITLE
Update Nudge.munki.recipe to fix minimum_os_version in pkginfo file

### DIFF
--- a/Nudge/Nudge.munki.recipe
+++ b/Nudge/Nudge.munki.recipe
@@ -97,6 +97,18 @@
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>minimum_os_version</key>
+                    <string>11.0</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>faux_root</key>
                 <string>%RECIPE_CACHE_DIR%/payload</string>
                 <key>installs_item_paths</key>
@@ -120,8 +132,6 @@
                 <string>%MUNKI_REPO_SUBDIR%</string>
                 <key>version_comparison_key</key>
                 <string>CFBundleVersion</string>
-                <key>minimum_os_version</key>
-                <string>11.0</string>
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>


### PR DESCRIPTION
 moved minimum_os_version from the final MunkiImport processor to a new MunkiPkginfoMerger earlier in the recipe. Prior to this, the minimum_os_version was being ignored, and 10.5.0 was in the resulting file instead of 11.0