### PR TITLE
Nudge: Fixes munki recipe for Nudge_Suite

### DIFF
--- a/Nudge/Nudge.munki.recipe
+++ b/Nudge/Nudge.munki.recipe
@@ -69,15 +69,26 @@
                 <string>%found_filename%/Payload</string>
                 <key>destination_path</key>
                 <string>%RECIPE_CACHE_DIR%/payload/Applications/Utilities</string>
+                <key>purge_destination</key>
+                <true/>
             </dict>
             <key>Processor</key>
             <string>PkgPayloadUnpacker</string>
         </dict>
         <dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/payload/**/Nudge.app/Contents/Info.plist</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/payload/Applications/Utilities/Nudge.app/Contents/Info.plist</string>
+                <string>%found_filename%</string>
             </dict>
             <key>Processor</key>
             <string>Versioner</string>


### PR DESCRIPTION
When trying to import the Nudge Suite to Munki we have encountered the following error:

```
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked %RECIPE_CACHE_DIR%/unpack/Nudge_Suite-1.1.11.81465.pkg/Payload to %RECIPE_CACHE_DIR%/payload/Applications/Utilities
Versioner
File '%RECIPE_CACHE_DIR%/payload/Applications/Utilities/Nudge.app/Contents/Info.plist' was not found.
Failed.
```

Reason for this was, that Nudge.app was actually unpacked to the following path:
`%RECIPE_CACHE_DIR%/payload/Applications/Utilities/Applications/Utilities`

The default recipe unpacks Nudge.app to:
`%RECIPE_CACHE_DIR%/payload/Applications/Utilities`

I don't see any reason for this difference in the PkgPayloadUnpacker source. But to handle both cases, I have added a FileFinder step to find the actual app bundle.

The purge_destination flag in the PkgPayloadUnpacker makes sure that we do not have multiple app bundles in our cache if we try to switch from the default Nudge to Nudge Suite.