### PR TITLE
Update Nudge.munki.recipe

### DIFF
--- a/Nudge/Nudge.munki.recipe
+++ b/Nudge/Nudge.munki.recipe
@@ -5,13 +5,17 @@
     <key>Description</key>
     <string>Downloads latest Nudge release and imports into Munki.
 
-Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.
+
+Set the ESSENTIALS_UNPACK_PATH variable to "/Applications/Utilities" when downloading the Essentials pkg. Leave empty for all others.</string>
     <key>Identifier</key>
     <string>com.github.erikng.munki.Nudge</string>
     <key>Input</key>
     <dict>
         <key>DERIVE_MIN_OS</key>
         <string>YES</string>
+        <key>ESSENTIALS_UNPACK_PATH</key>
+        <string></string>
         <key>NAME</key>
         <string>Nudge</string>
         <key>MUNKI_REPO_SUBDIR</key>
@@ -113,7 +117,7 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
             <key>Arguments</key>
             <dict>
                 <key>faux_root</key>
-                <string>%RECIPE_CACHE_DIR%/payload</string>
+                <string>%RECIPE_CACHE_DIR%/payload%ESSENTIALS_UNPACK_PATH%</string>
                 <key>derive_minimum_os_version</key>
                 <string>%DERIVE_MIN_OS%</string>
                 <key>installs_item_paths</key>
@@ -140,18 +144,6 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>path_list</key>
-                <array>
-                    <string>%RECIPE_CACHE_DIR%/unpack</string>
-                    <string>%RECIPE_CACHE_DIR%/payload</string>
-                </array>
-            </dict>
-            <key>Processor</key>
-            <string>PathDeleter</string>
         </dict>
     </array>
 </dict>

--- a/Nudge/Nudge.munki.recipe
+++ b/Nudge/Nudge.munki.recipe
@@ -3,11 +3,15 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads latest Nudge release and imports into Munki.</string>
+    <string>Downloads latest Nudge release and imports into Munki.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.erikng.munki.Nudge</string>
     <key>Input</key>
     <dict>
+        <key>DERIVE_MIN_OS</key>
+        <string>YES</string>
         <key>NAME</key>
         <string>Nudge</string>
         <key>MUNKI_REPO_SUBDIR</key>
@@ -35,7 +39,7 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>2.7</string>
     <key>ParentRecipe</key>
     <string>com.github.erikng.download.Nudge</string>
     <key>Process</key>
@@ -108,20 +112,10 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>additional_pkginfo</key>
-                <dict>
-                    <key>minimum_os_version</key>
-                    <string>11.0</string>
-                </dict>
-            </dict>
-            <key>Processor</key>
-            <string>MunkiPkginfoMerger</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
                 <key>faux_root</key>
                 <string>%RECIPE_CACHE_DIR%/payload</string>
+                <key>derive_minimum_os_version</key>
+                <string>%DERIVE_MIN_OS%</string>
                 <key>installs_item_paths</key>
                 <array>
                     <string>/Applications/Utilities/Nudge.app</string>
@@ -146,6 +140,18 @@
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/unpack</string>
+                    <string>%RECIPE_CACHE_DIR%/payload</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
         </dict>
     </array>
 </dict>

--- a/Nudge/Nudge.munki.recipe
+++ b/Nudge/Nudge.munki.recipe
@@ -145,6 +145,18 @@ Set the ESSENTIALS_UNPACK_PATH variable to "/Applications/Utilities" when downlo
             <key>Processor</key>
             <string>MunkiImporter</string>
         </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/unpack</string>
+                    <string>%RECIPE_CACHE_DIR%/payload</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
+        </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
Hi, @erikng 

The current Munki recipe has the `minimum_os_version` key hard coded to macOS 11.

This PR adds support for `derive_minimum_os_version` which now sets the `minimum_os_version` to macOS 12

I've also added in PathDeleter to clean up the unpacking steps. 

Output from a successful -v run
```
autopkg run -v Nudge.munki.recipe 
Looking for com.github.erikng.download.Nudge...
Did not find com.github.erikng.download.Nudge in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.erikng.download.Nudge...
Found com.github.erikng.download.Nudge in recipe map
**load_recipe time: 0.005228249996434897
Processing Nudge.munki.recipe...
WARNING: Nudge.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
WARNING: This is an unathenticated Github session, some API features may not work
GitHubReleasesInfoProvider: Matched regex 'Nudge-\S.*?.pkg' among asset(s): Nudge-2.0.5.81760.pkg
GitHubReleasesInfoProvider: Selected asset 'Nudge-2.0.5.81760.pkg' from tag 'v2.0.5.81760' at url https://github.com/macadmins/nudge/releases/download/v2.0.5.81760/Nudge-2.0.5.81760.pkg
URLDownloader
URLDownloader: Storing new Last-Modified header: Thu, 25 Jul 2024 21:37:56 GMT
URLDownloader: Storing new ETag header: "0x8DCACF20C446501"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.erikng.munki.Nudge/downloads/Nudge.pkg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Nudge.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-07-25 21:35:19 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Mac Admins Open Source (T4SK8ZXCXG)
CodeSignatureVerifier:        Expires: 2028-02-09 02:34:05 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B1 06 B6 26 DA 3B A8 48 34 F3 DF D2 CC 5E AC 03 91 31 05 3F A9 A2 
CodeSignatureVerifier:            B7 BA 2A 5E 33 3C 3B 05 53 7A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2031-09-17 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F1 6C D3 C5 4C 7F 83 CE A4 BF 1A 3E 6A 08 19 C8 AA A8 E4 A1 52 8F 
CodeSignatureVerifier:            D1 44 71 5F 35 06 43 D2 DF 3A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FlatPkgUnpacker
FlatPkgUnpacker: Unpacked /Users/paul.cossey/Library/AutoPkg/Cache/com.github.erikng.munki.Nudge/downloads/Nudge.pkg to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.erikng.munki.Nudge/unpack
FileFinder
FileFinder: Found file match: '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.erikng.munki.Nudge/unpack/Nudge-2.0.5.81760.pkg' from globbed '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.erikng.munki.Nudge/unpack/Nudge*.pkg'
FileFinder: Basename match: 'Nudge-2.0.5.81760.pkg'
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul.cossey/Library/AutoPkg/Cache/com.github.erikng.munki.Nudge/unpack/Nudge-2.0.5.81760.pkg/Payload to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.erikng.munki.Nudge/payload/Applications/Utilities
FileFinder
FileFinder: Found file match: '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.erikng.munki.Nudge/payload/Applications/Utilities/Nudge.app/Contents/Info.plist' from globbed '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.erikng.munki.Nudge/payload/**/Nudge.app/Contents/Info.plist'
FileFinder: Basename match: 'Info.plist'
Versioner
Versioner: Found version 2.0.5.81760 in file /Users/paul.cossey/Library/AutoPkg/Cache/com.github.erikng.munki.Nudge/payload/Applications/Utilities/Nudge.app/Contents/Info.plist
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '2.0.5.81760'} into pkginfo
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/Utilities/Nudge.app
MunkiInstallsItemsCreator: Derived minimum os version as: 12.0
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '2.0.5.81760', 'installs': [{'CFBundleIdentifier': 'com.github.macadmins.Nudge', 'CFBundleName': 'Nudge', 'CFBundleShortVersionString': '2.0.5.81760', 'CFBundleVersion': '2.0.5.81760', 'minosversion': '12.0', 'path': '/Applications/Utilities/Nudge.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '12.0'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Nudge/Nudge-2.0.5.81760.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Nudge/Nudge-2.0.5.81760.pkg
PathDeleter
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/com.github.erikng.munki.Nudge/unpack
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/com.github.erikng.munki.Nudge/payload
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.erikng.munki.Nudge/receipts/Nudge.munki-receipt-20240801-122350.plist

The following new items were downloaded:
    Download Path                                                                               
    -------------                                                                               
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.erikng.munki.Nudge/downloads/Nudge.pkg  

The following new items were imported into Munki:
    Name   Version      Catalogs  Pkginfo Path                        Pkg Repo Path                     Icon Repo Path  
    ----   -------      --------  ------------                        -------------                     --------------  
    Nudge  2.0.5.81760  testing   apps/Nudge/Nudge-2.0.5.81760.plist  apps/Nudge/Nudge-2.0.5.81760.pkg
```